### PR TITLE
fix: Add `DateCreated` tags to Azure resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,5 @@
+locals {
+  tags = {
+    DateCreated = timestamp()
+  }
+}


### PR DESCRIPTION
Closes #247